### PR TITLE
fix(markdown): add blank line to render heading

### DIFF
--- a/content/Movement/jumpstore.md
+++ b/content/Movement/jumpstore.md
@@ -12,6 +12,7 @@ socialDescription: One of the moves in Rain World 3
 jumpstorage
 js
 </div>
+
 ## Description
 Jump-boost is a value in the game's code which determines height during certain moves, based on how long jump is held as the move begins. For most moves, it is set to a non-zero value as slugcat leaves the ground, and is "cashed in" for upwards velocity for every frame jump is held.
 


### PR DESCRIPTION

<img width="1350" height="722" alt="Screenshot 2026-01-17 223416" src="https://github.com/user-attachments/assets/ad153ef0-947f-4973-b393-400248038189" />
Ensure `## Description` is parsed as a Markdown heading by adding a blank line after the closing </div>.